### PR TITLE
Add currency array

### DIFF
--- a/ByteCoin/Model/CoinManager.swift
+++ b/ByteCoin/Model/CoinManager.swift
@@ -12,5 +12,5 @@ struct CoinManager {
     
     let baseURL = "https://rest.coinapi.io/v1/exchangerate/BTC"
     let apiKey = "YOUR_API_KEY_HERE"
-    
+    let currencyArray = ["AUD", "BRL","CAD","CNY","EUR","GBP","HKD","IDR","ILS","INR","JPY","MXN","NOK","NZD","PLN","RON","RUB","SEK","SGD","USD","ZAR"]
 }


### PR DESCRIPTION
Students do not need to manually type in currencyArray.
lesson 166 step 2 assumes this is present. First paragraph needs updated to show 3 constants (including new apiKey)